### PR TITLE
Add failing test with mocha

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const {
+  Controller,
+  RSVP,
+  get
+} = Ember;
+
+const { Promise } = RSVP;
+
+export default Controller.extend({
+  actions: {
+    doSomething() {
+      const flashMessages = get(this, 'flashMessages');
+      const promise = new Promise((resolve/*, reject */) => {
+        resolve("HELLO");
+      });
+
+      promise.then((value) => {
+        flashMessages.success(value);
+      });
+    }
+  }
+});

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,7 +1,11 @@
 {{#each flashMessages.queue as |flash|}}
-  {{flash-message flash=flash}}
+  <div id="flash-message">
+    {{flash-message flash=flash}}
+  </div>
 {{/each}}
 
 <h1>Hello!</h1>
+
+<button class="button-with-flash-message" {{action "doSomething"}}>Do the thing</button>
 
 {{outlet}}

--- a/tests/acceptance/test-the-thing-test.js
+++ b/tests/acceptance/test-the-thing-test.js
@@ -1,0 +1,38 @@
+/* jshint expr:true */
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+
+const { run } = Ember;
+
+describe('Acceptance: TestTheThing', function() {
+  let application;
+
+  beforeEach(function() {
+    application = startApp();
+  });
+
+  afterEach(function() {
+    run(application, 'destroy');
+  });
+
+  it('can click the button', function(done) {
+    visit('/');
+
+    click('.button-with-flash-message');
+
+    andThen(() => {
+      const flashMessage = find('#flash-message').text().trim();
+
+      expect(flashMessage).to.equal('HELLO');
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
The test included in this PR fails with the following error:

```
Acceptance: TestTheThing

can click the button ‣
  Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
      at assets/test-support.js:7367:19

"after each" hook ‣
  TypeError: find(...).text is not a function
      at assets/ember-cli-flash-and-mocha.js:331:51
      at andThen (assets/vendor.js:52664:33)
      at assets/vendor.js:53350:19
      at isolate (assets/vendor.js:53551:13)
      at assets/vendor.js:53535:14
      at tryCatch (assets/vendor.js:66705:14)
      at invokeCallback (assets/vendor.js:66720:15)
      at publish (assets/vendor.js:66688:9)
      at assets/vendor.js:43131:7
      at Queue.invoke (assets/vendor.js:11464:16)
```
