### PR TITLE
Add failing test with qunit

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const {
+  Controller,
+  RSVP,
+  get
+} = Ember;
+
+const { Promise } = RSVP;
+
+export default Controller.extend({
+  actions: {
+    doSomething() {
+      const flashMessages = get(this, 'flashMessages');
+      const promise = new Promise((resolve/*, reject */) => {
+        resolve("HELLO");
+      });
+
+      promise.then((value) => {
+        flashMessages.success(value);
+      });
+    }
+  }
+});

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,7 +1,11 @@
 {{#each flashMessages.queue as |flash|}}
-  {{flash-message flash=flash}}
+  <div id="flash-message">
+    {{flash-message flash=flash}}
+  </div>
 {{/each}}
 
 <h1>Hello!</h1>
+
+<button class="button-with-flash-message" {{action "doSomething"}}>Do the thing</button>
 
 {{outlet}}

--- a/tests/acceptance/test-the-button-test.js
+++ b/tests/acceptance/test-the-button-test.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from 'ember-cli-flash-and-mocha/tests/helpers/start-app';
+
+module('Acceptance | test the button', {
+  beforeEach: function() {
+    this.application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('it works with qunit', function(assert) {
+  assert.expect(1);
+
+  visit('/');
+
+  click('.button-with-flash-message');
+
+  andThen(() => {
+    const flashMessage = find('#flash-message').text().trim();
+
+    assert.equal(flashMessage, 'HELLO', 'it works with qunit');
+  });
+});


### PR DESCRIPTION
Same as with https://github.com/HeroicEric/ember-cli-flash-and-mocha/compare/failing-with-qunit?expand=1 except this doesn't fail on timeout. In this case, it seems that the code inside `andThen` waits until the flash message disappears before it runs.

The test included in this PR fails with:

```
Acceptance: TestTheThing

it works with qunit@ 3202 ms
Expected:   
"HELLO"
Result:     
""
Diff:   
"HELLO"
Source:     
    at http://localhost:4200/assets/ember-cli-flash-and-mocha.js:331:14
    at andThen (http://localhost:4200/assets/vendor.js:52664:33)
    at http://localhost:4200/assets/vendor.js:53350:19
    at isolate (http://localhost:4200/assets/vendor.js:53551:13)
    at http://localhost:4200/assets/vendor.js:53535:14
    at tryCatch (http://localhost:4200/assets/vendor.js:66705:14)
```
